### PR TITLE
Track finished jobs and skip processed files

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -37,6 +37,10 @@
     .btn-resume { background:#16a34a; }
     .btn-kill { background:#ef4444; }
     .stopping { opacity: .6; }
+    .hist { height: 15vh; overflow:auto; border: 1px dashed #e5e7eb; border-radius: 10px; padding:8px; background:#fafafa; }
+    .hitem { padding:4px 6px; border-bottom:1px solid #eee; font-size:13px; }
+    .hitem.ok { color: var(--ok); }
+    .hitem.err { color: var(--danger); }
     /* Settings drawer */
     .drawer { position: fixed; top:0; right:-420px; width: 380px; height: 100%; background:#ffffff; box-shadow: -4px 0 16px rgba(0,0,0,.15); border-left:1px solid #e5e7eb; transition: right .2s ease; z-index:2000; display:flex; flex-direction:column; }
     .drawer.open { right:0; }
@@ -89,6 +93,12 @@
         <h3>Jobs</h3>
         <div id="jobs" class="grid"></div>
       </section>
+      <section class="panel">
+        <h3>Finished</h3>
+        <div id="finished" class="hist"></div>
+        <h3 style="margin-top:10px;">Errors</h3>
+        <div id="errors" class="hist"></div>
+      </section>
     </section>
     <section class="panel">
       <h3>Logs</h3>
@@ -139,6 +149,8 @@
     const autoScanEl = document.getElementById('autoScan');
     const intervalEl = document.getElementById('scanInterval');
     const workersEl = document.getElementById('workers');
+    const doneEl = document.getElementById('finished');
+    const errEl = document.getElementById('errors');
 
     // Drawer elements
     const crfEl = document.getElementById('crf');
@@ -285,6 +297,28 @@
       logEl.textContent += `[${time}] ${text}\n`;
       if(atBottom){ logEl.scrollTop = logEl.scrollHeight; }
     }
+    function addHistory(file, ok){
+      const target = ok ? doneEl : errEl;
+      const other = ok ? errEl : doneEl;
+      for(const el of Array.from(target.children)){
+        if(el.textContent === file){ el.remove(); }
+      }
+      for(const el of Array.from(other.children)){
+        if(el.textContent === file){ el.remove(); }
+      }
+      const el = document.createElement('div');
+      el.className = 'hitem ' + (ok ? 'ok' : 'err');
+      el.textContent = file;
+      target.appendChild(el);
+    }
+    async function loadHistory(){
+      const res = await fetch('/finished');
+      const data = await res.json();
+      doneEl.innerHTML = '';
+      errEl.innerHTML = '';
+      for(const f of data.done || []) addHistory(f, true);
+      for(const f of data.errors || []) addHistory(f, false);
+    }
     async function loadCfg(){
       const res = await fetch('/config'); const cfg = await res.json();
       const x = cfg.xcode || {};
@@ -309,7 +343,7 @@
     intervalEl.onchange = async ()=>{ await api('/options', {scan_interval: Number(intervalEl.value)}); appendLog(`Scan interval set to ${intervalEl.options[intervalEl.selectedIndex].text}.`); };
     workersEl.onchange = async ()=>{ const r = await api('/options', {concurrency: Number(workersEl.value)}); appendLog(`Workers set to ${workersEl.value}.`); };
 
-    loadCfg(); loadQueue();
+    loadCfg(); loadQueue(); loadHistory();
 
     const wsProto = location.protocol === 'https:' ? 'wss':'ws';
     const ws = new WebSocket(`${wsProto}://${location.host}/ws`);
@@ -318,7 +352,7 @@
         const m = JSON.parse(ev.data);
         if(m.type === 'log'){ appendLog(m.message); }
         else if(m.type === 'progress'){ updateJob(m); }
-        else if(m.type === 'done'){ appendLog(`${m.ok?'[ok]':'[error]'} ${m.file}`); removeJob(m.file); }
+        else if(m.type === 'done'){ appendLog(`${m.ok?'[ok]':'[error]'} ${m.file}`); removeJob(m.file); addHistory(m.file, m.ok); }
         else if(m.type === 'queue_reset'){ qReset(); }
         else if(m.type === 'queue_append'){ qAppend(m.items || [], m.total); }
         else if(m.type === 'queue_pop'){ qPop(m.file); }


### PR DESCRIPTION
## Summary
- track completed and errored files in memory
- expose `/finished` endpoint and skip processed files on rescans
- add UI lists for finished and errored jobs
- keep finished/error history in sync when files are retried

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899e6710dd0832f960df33dfa36153e