### PR TITLE
Track finished jobs and skip processed files

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ import os, asyncio, json, time, signal, unicodedata
 from pathlib import Path
 from typing import List, Dict, Any, Optional
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Query, Body
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Body
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
@@ -44,6 +44,12 @@ CURRENT_PROCS:Dict[str,asyncio.subprocess.Process]={}   # keyed by normalized pa
 ORIG_NAME:Dict[str,str]={}                               # normalized -> original path string
 PAUSED_SET:set[str]=set()
 OPTIONS={"continuous_scan": False, "scan_interval": 60, "concurrency": 1, "auto_start": True}
+
+# Track finished and errored files so rescans can skip them and the UI can show history
+DONE_FILES:List[str]=[]     # successfully processed files (original paths)
+ERROR_FILES:List[str]=[]    # files that failed to process
+DONE_KEYS:set[str]=set()
+ERROR_KEYS:set[str]=set()
 
 # ---------- Helpers ----------
 def nkey(p:str)->str:
@@ -159,6 +165,7 @@ async def process_file(src:str):
     await wlog(f"Processing: {src} (duration={dur if dur else 'unknown'}s) transcode={trans}")
     if RUNTIME["dry_run"]: await wlog(f"[DRY_RUN] Would {'transcode' if trans else 'remux'} -> {dst}"); return True
 
+    key=nkey(src)
     rc=await run_ffmpeg(src,tmp,dur,trans)
     if rc==0:
         if RUNTIME["preserve_timestamps"]:
@@ -168,11 +175,21 @@ async def process_file(src:str):
         if not RUNTIME["keep_original"] and os.path.abspath(dst)!=os.path.abspath(src):
             try: os.remove(src)
             except Exception as e: await wlog(f"[warn] Could not remove original: {e}")
+        ERROR_KEYS.discard(key)
+        try: ERROR_FILES.remove(src)
+        except ValueError: pass
+        DONE_KEYS.add(key)
+        if src not in DONE_FILES: DONE_FILES.append(src)
         await wlog(f"[ok] {src} -> {dst}"); await ws.send({"type":"done","file":src,"ok":True})
     else:
-        try: 
+        try:
             if os.path.exists(tmp): os.remove(tmp)
         except Exception: pass
+        DONE_KEYS.discard(key)
+        try: DONE_FILES.remove(src)
+        except ValueError: pass
+        ERROR_KEYS.add(key)
+        if src not in ERROR_FILES: ERROR_FILES.append(src)
         await wlog(f"[error] ffmpeg rc={rc} for {src}"); await ws.send({"type":"done","file":src,"ok":False})
     return rc==0
 
@@ -208,12 +225,18 @@ async def get_queue():
     async with QUEUE_LOCK: items=[{"file":f,"dir":str(Path(f).parent)} for f in QUEUE]; total=len(QUEUE)
     return {"total":total,"items":items}
 
+@app.get("/finished")
+async def finished_jobs():
+    """Return lists of successfully processed and errored files."""
+    return {"done": DONE_FILES, "errors": ERROR_FILES}
+
 @app.post("/scan")
 async def api_scan():
     global QUEUE
     async with QUEUE_LOCK: QUEUE=[]
     await ws.send({"type":"queue_reset"})
-    running_keys=set(CURRENT_PROCS.keys())|set(PAUSED_SET)
+    # Skip currently running, paused, already done, or previously errored files
+    running_keys=set(CURRENT_PROCS.keys())|set(PAUSED_SET)|DONE_KEYS|ERROR_KEYS
     added=[]
     for d,_,files in os.walk(TARGET_DIR):
         for name in files:

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -37,6 +37,10 @@
     .btn-resume { background:#16a34a; }
     .btn-kill { background:#ef4444; }
     .stopping { opacity: .6; }
+    .hist { height: 15vh; overflow:auto; border: 1px dashed #e5e7eb; border-radius: 10px; padding:8px; background:#fafafa; }
+    .hitem { padding:4px 6px; border-bottom:1px solid #eee; font-size:13px; }
+    .hitem.ok { color: var(--ok); }
+    .hitem.err { color: var(--danger); }
     /* Settings drawer */
     .drawer { position: fixed; top:0; right:-420px; width: 380px; height: 100%; background:#ffffff; box-shadow: -4px 0 16px rgba(0,0,0,.15); border-left:1px solid #e5e7eb; transition: right .2s ease; z-index:2000; display:flex; flex-direction:column; }
     .drawer.open { right:0; }
@@ -89,6 +93,12 @@
         <h3>Jobs</h3>
         <div id="jobs" class="grid"></div>
       </section>
+      <section class="panel">
+        <h3>Finished</h3>
+        <div id="finished" class="hist"></div>
+        <h3 style="margin-top:10px;">Errors</h3>
+        <div id="errors" class="hist"></div>
+      </section>
     </section>
     <section class="panel">
       <h3>Logs</h3>
@@ -139,6 +149,8 @@
     const autoScanEl = document.getElementById('autoScan');
     const intervalEl = document.getElementById('scanInterval');
     const workersEl = document.getElementById('workers');
+    const doneEl = document.getElementById('finished');
+    const errEl = document.getElementById('errors');
 
     // Drawer elements
     const crfEl = document.getElementById('crf');
@@ -285,6 +297,28 @@
       logEl.textContent += `[${time}] ${text}\n`;
       if(atBottom){ logEl.scrollTop = logEl.scrollHeight; }
     }
+    function addHistory(file, ok){
+      const target = ok ? doneEl : errEl;
+      const other = ok ? errEl : doneEl;
+      for(const el of Array.from(target.children)){
+        if(el.textContent === file){ el.remove(); }
+      }
+      for(const el of Array.from(other.children)){
+        if(el.textContent === file){ el.remove(); }
+      }
+      const el = document.createElement('div');
+      el.className = 'hitem ' + (ok ? 'ok' : 'err');
+      el.textContent = file;
+      target.appendChild(el);
+    }
+    async function loadHistory(){
+      const res = await fetch('/finished');
+      const data = await res.json();
+      doneEl.innerHTML = '';
+      errEl.innerHTML = '';
+      for(const f of data.done || []) addHistory(f, true);
+      for(const f of data.errors || []) addHistory(f, false);
+    }
     async function loadCfg(){
       const res = await fetch('/config'); const cfg = await res.json();
       const x = cfg.xcode || {};
@@ -309,7 +343,7 @@
     intervalEl.onchange = async ()=>{ await api('/options', {scan_interval: Number(intervalEl.value)}); appendLog(`Scan interval set to ${intervalEl.options[intervalEl.selectedIndex].text}.`); };
     workersEl.onchange = async ()=>{ const r = await api('/options', {concurrency: Number(workersEl.value)}); appendLog(`Workers set to ${workersEl.value}.`); };
 
-    loadCfg(); loadQueue();
+    loadCfg(); loadQueue(); loadHistory();
 
     const wsProto = location.protocol === 'https:' ? 'wss':'ws';
     const ws = new WebSocket(`${wsProto}://${location.host}/ws`);
@@ -318,7 +352,7 @@
         const m = JSON.parse(ev.data);
         if(m.type === 'log'){ appendLog(m.message); }
         else if(m.type === 'progress'){ updateJob(m); }
-        else if(m.type === 'done'){ appendLog(`${m.ok?'[ok]':'[error]'} ${m.file}`); removeJob(m.file); }
+        else if(m.type === 'done'){ appendLog(`${m.ok?'[ok]':'[error]'} ${m.file}`); removeJob(m.file); addHistory(m.file, m.ok); }
         else if(m.type === 'queue_reset'){ qReset(); }
         else if(m.type === 'queue_append'){ qAppend(m.items || [], m.total); }
         else if(m.type === 'queue_pop'){ qPop(m.file); }


### PR DESCRIPTION
## Summary
- track completed and errored files in memory
- expose `/finished` endpoint and skip processed files on rescans
- add UI lists for finished and errored jobs
- keep finished/error history in sync when files are retried
- drop unused `Query` import

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6899e6710dd0832f960df33dfa36153e